### PR TITLE
file: ./coverage/lcov.info is deprecated in codecov-action@v5

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
       with:
-        file: ./coverage/lcov.info
+        files: ./coverage/lcov.info
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false


### PR DESCRIPTION
The Issue:

- file: ./coverage/lcov.info is deprecated in codecov-action@v5
- Should be files: ./coverage/lcov.info (note the 's' at the end)